### PR TITLE
Update readme to set Content-Type for simple post

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,13 @@ fetch('https://api.github.com/users/github')
 
 #### Simple Post
 ```js
-fetch('https://httpbin.org/post', { method: 'POST', body: 'a=1' })
+fetch('https://httpbin.org/post', { 
+    method: 'POST', 
+    body: 'a=1', 
+    headers: {
+        'Content-Type': 'application/x-www-form-urlencoded'
+      }
+    })
     .then(res => res.json()) // expecting a json response
     .then(json => console.log(json));
 ```


### PR DESCRIPTION
Simple post body of type string requires the headers: 

```
headers: {
        'Content-Type': 'application/x-www-form-urlencoded'
      }
    })
```

To be set.

Related to issue: https://github.com/bitinn/node-fetch/issues/565